### PR TITLE
Bug/Fix Code of Conduct Breaking Link

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -26,4 +26,4 @@ A clear and concise description of what you expected to happen.
 ## Additional Context
 Add any other context about the problem here.
 
-- [ ] I will abide by the [code of conduct](https://github.com/bhavik2936/dot-files/blob/main/CODE_OF_CONDUCT.md).
+- [ ] I will abide by the [code of conduct](https://github.com/bhavik2936/dot-files/blob/main/.github/CODE_OF_CONDUCT.md).

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -24,4 +24,4 @@ A clear and concise description of any alternative solutions or features you've 
 ## Additional Context
 Add any other context or screenshots about the feature request here.
 
-- [ ] I will abide by the [code of conduct](https://github.com/bhavik2936/dot-files/blob/main/CODE_OF_CONDUCT.md).
+- [ ] I will abide by the [code of conduct](https://github.com/bhavik2936/dot-files/blob/main/.github/CODE_OF_CONDUCT.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,4 +7,4 @@ Add a description about proposed changes addressed into the PR.
 ## Why
 Add some context for the need of raising the PR.
 
-- [ ] I will abide by the [code of conduct](https://github.com/bhavik2936/dot-files/blob/main/CODE_OF_CONDUCT.md).
+- [ ] I will abide by the [code of conduct](https://github.com/bhavik2936/dot-files/blob/main/.github/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## What
Fixed broken link to Code of Conduct file.

## Why
Breaking links in PR and Issue templates must be fixed.

- [x] I will abide by the [code of conduct](https://github.com/bhavik2936/dot-files/blob/main/.github/CODE_OF_CONDUCT.md).
