### PR TITLE
fix: Updated order for sourcing in .zlogin file.

### DIFF
--- a/.zlogin
+++ b/.zlogin
@@ -1,5 +1,5 @@
 # Load the shell dotfiles
-for file in ~/.dotfiles/.{path,exports,aliases,sources,functions,extra}; do
+for file in ~/.dotfiles/.{exports,path,aliases,sources,functions,extra}; do
 	[ -r "$file" ] && [ -f "$file" ] && source "$file";
 done;
 unset file;


### PR DESCRIPTION
**The PR tries to resolve #4 .**

## What
Updated order for sourcing exports before path to instantiate them before call.

## Why
As many variables from .exports file may get called in .path file; .exports file should be sourced first to instantiate them before call.

- [x] I will abide by the [code of conduct](https://github.com/bhavik2936/dot-files/blob/main/.github/CODE_OF_CONDUCT.md).
